### PR TITLE
feat: Add modular visualizations

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod app;
 mod audio;
 mod db;
 mod ui;
+mod visualizations;
 
 use std::env;
 use std::error::Error;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,15 +1,14 @@
 use crate::app::AppMode;
 use crate::audio::AudioVisualizer;
 use crate::db::Station;
+use crate::visualizations::VisualizationManager;
 mod popup;
+mod vis_menu;
 use ratatui::{
     layout::{Constraint, Direction, Layout},
     style::{Color, Modifier, Style},
     text::Span,
-    widgets::{
-        canvas::{Canvas, Line, Rectangle},
-        Block, Borders, List, ListItem, ListState, Paragraph,
-    },
+    widgets::{canvas::Canvas, Block, Borders, List, ListItem, ListState, Paragraph},
     Frame,
 };
 
@@ -25,6 +24,8 @@ pub fn ui(
     add_station_desc: &str,
     input_field: usize,
     input_cursor: usize,
+    vis_manager: &VisualizationManager,
+    vis_menu_state: &mut ListState,
 ) {
     let size = f.size();
 
@@ -85,151 +86,14 @@ pub fn ui(
         .constraints([Constraint::Percentage(70), Constraint::Percentage(30)].as_ref())
         .split(main_chunks[1]);
 
-    // Create 90s starfield visualization using canvas
+    // Create a canvas with the active visualization
     let canvas = Canvas::default()
         .block(vis_block)
         .x_bounds([0.0, 100.0])
         .y_bounds([0.0, 100.0])
         .paint(|ctx| {
-            // Background - dark space
-            ctx.draw(&Rectangle {
-                x: 0.0,
-                y: 0.0,
-                width: 100.0,
-                height: 100.0,
-                color: Color::Rgb(0, 0, 20), // Very dark blue
-            });
-
-            // Star color palette
-            let colors = [
-                Color::Rgb(255, 255, 255), // White
-                Color::Rgb(200, 200, 255), // Light blue
-                Color::Rgb(255, 230, 200), // Light yellow
-                Color::Rgb(255, 200, 200), // Light red
-                Color::Rgb(200, 255, 200), // Light green
-            ];
-
-            // Draw each star in the starfield
-            for star in &state.stars {
-                // Calculate projected position based on perspective
-                // As z gets closer to 1.0, the star gets closer to the center
-                // and appears larger
-
-                // Center of screen
-                let center_x = 50.0;
-                let center_y = 50.0;
-
-                // Calculate projected position (perspective projection)
-                // Higher z = closer to viewer = further from center
-                let scale = 1.0 / (1.01 - star.z.min(0.99)); // Avoid division by zero
-                let projected_x = center_x + star.x * scale * 40.0; // Scale factor for width
-                let projected_y = center_y + star.y * scale * 40.0; // Scale factor for height
-
-                // Calculate size based on z (closer = larger)
-                // Use non-linear scaling for more dramatic effect
-                let size = star.z.powf(2.0) * 3.0 * (state.warp_speed * 0.5 + 0.5);
-
-                // Calculate brightness based on z and intrinsic brightness
-                let brightness = star.brightness * star.z.powf(1.5);
-
-                // Skip if star is out of bounds
-                if !(0.0..=100.0).contains(&projected_x) || !(0.0..=100.0).contains(&projected_y) {
-                    continue;
-                }
-
-                // Get color for this star
-                let base_color = colors[star.color as usize % colors.len()];
-
-                // Adjust color based on brightness
-                let color = match base_color {
-                    Color::Rgb(r, g, b) => Color::Rgb(
-                        (r as f64 * brightness) as u8,
-                        (g as f64 * brightness) as u8,
-                        (b as f64 * brightness) as u8,
-                    ),
-                    _ => base_color,
-                };
-
-                // Draw the star
-                ctx.draw(&Rectangle {
-                    x: projected_x - size / 2.0,
-                    y: projected_y - size / 2.0,
-                    width: size,
-                    height: size,
-                    color,
-                });
-
-                // For closer stars, add a trail/streak effect when at high warp speed
-                if star.z > 0.7 && state.warp_speed > 1.5 {
-                    // Calculate trail length based on speed and z
-                    let trail_length = star.z * state.warp_speed * 5.0;
-
-                    // Direction from center
-                    let dx = projected_x - center_x;
-                    let dy = projected_y - center_y;
-                    let dist = (dx * dx + dy * dy).sqrt();
-
-                    if dist > 0.0 {
-                        // Normalized direction
-                        let nx = dx / dist;
-                        let ny = dy / dist;
-
-                        // Draw trail pointing outward from center
-                        let trail_x = projected_x - nx * trail_length;
-                        let trail_y = projected_y - ny * trail_length;
-
-                        // Make trail fade out
-                        let trail_color = match color {
-                            Color::Rgb(r, g, b) => Color::Rgb(
-                                (r as f64 * 0.5) as u8,
-                                (g as f64 * 0.5) as u8,
-                                (b as f64 * 0.5) as u8,
-                            ),
-                            _ => color,
-                        };
-
-                        ctx.draw(&Line {
-                            x1: trail_x,
-                            y1: trail_y,
-                            x2: projected_x,
-                            y2: projected_y,
-                            color: trail_color,
-                        });
-                    }
-                }
-            }
-
-            // Draw warp speed indicator
-            let warp = state.warp_speed;
-            if state.is_playing {
-                let indicator_width = 20.0;
-                let indicator_height = 5.0;
-                let x = 50.0 - indicator_width / 2.0;
-                let y = 90.0;
-
-                // Draw background
-                ctx.draw(&Rectangle {
-                    x,
-                    y,
-                    width: indicator_width,
-                    height: indicator_height,
-                    color: Color::Rgb(30, 30, 50),
-                });
-
-                // Draw filled portion based on warp speed (1.0 to 3.0 mapped to 0-100%)
-                let fill_width = (warp - 1.0) / 2.0 * indicator_width;
-                ctx.draw(&Rectangle {
-                    x,
-                    y,
-                    width: fill_width.min(indicator_width),
-                    height: indicator_height,
-                    color: Color::Rgb(
-                        (100.0 + (155.0 * (warp - 1.0) / 2.0)) as u8,
-                        (200.0 - (150.0 * (warp - 1.0) / 2.0)) as u8,
-                        255,
-                    ),
-                });
-            }
+            // Use the current visualization from the manager
+            vis_manager.render(ctx, &state);
         });
 
     f.render_widget(canvas, vis_chunks[0]);
@@ -263,23 +127,30 @@ pub fn ui(
 
     // Render help area
     let help_text = match mode {
-        AppMode::Normal => "↑/↓: Navigate  ⏎: Play  s: Stop  f: Favorite  a: Add Station  q: Quit",
+        AppMode::Normal => "↑/↓: Navigate  ⏎: Play  s: Stop  f: Favorite  a: Add Station  v: Visualizations  q: Quit",
         AppMode::AddingStation => "Tab: Next Field  Enter: Confirm  Esc: Cancel",
+        AppMode::VisualizationMenu => "↑/↓: Navigate  Enter: Select  Esc: Cancel",
     };
 
     let help =
         Paragraph::new(help_text).block(Block::default().borders(Borders::ALL).title("Help"));
     f.render_widget(help, main_help_chunks[1]);
 
-    // If in add station mode, render the popup
-    if *mode == AppMode::AddingStation {
-        popup::render_add_station_popup(
-            f,
-            add_station_name,
-            add_station_url,
-            add_station_desc,
-            input_field,
-            input_cursor,
-        );
+    // Render the appropriate popup based on mode
+    match mode {
+        AppMode::AddingStation => {
+            popup::render_add_station_popup(
+                f,
+                add_station_name,
+                add_station_url,
+                add_station_desc,
+                input_field,
+                input_cursor,
+            );
+        }
+        AppMode::VisualizationMenu => {
+            vis_menu::render_visualization_menu(f, vis_manager, vis_menu_state, size);
+        }
+        _ => {}
     }
 }

--- a/src/ui/vis_menu.rs
+++ b/src/ui/vis_menu.rs
@@ -1,0 +1,100 @@
+use crate::visualizations::VisualizationManager;
+use ratatui::{
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::Span,
+    widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph},
+    Frame,
+};
+
+pub fn render_visualization_menu(
+    f: &mut Frame,
+    vis_manager: &VisualizationManager,
+    vis_menu_state: &mut ListState,
+    area: Rect,
+) {
+    // Create a centered popup
+    let popup_width = 50;
+    let popup_height = 15;
+    let popup_x = (area.width.saturating_sub(popup_width)) / 2;
+    let popup_y = (area.height.saturating_sub(popup_height)) / 2;
+
+    let popup_rect = Rect::new(
+        area.x + popup_x,
+        area.y + popup_y,
+        popup_width.min(area.width),
+        popup_height.min(area.height),
+    );
+
+    // Render clear behind the popup
+    f.render_widget(Clear, popup_rect);
+
+    // Create a block for the popup
+    let popup_block = Block::default()
+        .title("Select Visualization")
+        .borders(Borders::ALL)
+        .style(Style::default().bg(Color::DarkGray));
+
+    // Get visualizations
+    let vis_list = vis_manager.get_available_visualizations();
+
+    // Render the popup with a margin inside
+    let inner_popup = popup_block.inner(popup_rect);
+    f.render_widget(popup_block, popup_rect);
+
+    // Set up layout
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .margin(1)
+        .constraints(
+            [
+                Constraint::Length(8), // Visualization list
+                Constraint::Length(3), // Description
+            ]
+            .as_ref(),
+        )
+        .split(inner_popup);
+
+    // Create visualization list items
+    let items: Vec<ListItem> = vis_list
+        .iter()
+        .map(|(_, name, _)| ListItem::new(Span::styled(*name, Style::default().fg(Color::White))))
+        .collect();
+
+    // Create list widget with highlighting
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title("Available Visualizations"),
+        )
+        .highlight_style(
+            Style::default()
+                .fg(Color::Black)
+                .bg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol(">> ");
+
+    // Render the list with the state
+    f.render_stateful_widget(list, chunks[0], vis_menu_state);
+
+    // Show description of selected visualization
+    let description = if let Some(selected) = vis_menu_state.selected() {
+        if selected < vis_list.len() {
+            let (_, name, desc) = vis_list[selected];
+            format!("{}: {}", name, desc)
+        } else {
+            "Select a visualization".to_string()
+        }
+    } else {
+        "Select a visualization".to_string()
+    };
+
+    // Create and render the description paragraph
+    let desc_para = Paragraph::new(description)
+        .block(Block::default().borders(Borders::ALL).title("Description"))
+        .style(Style::default().fg(Color::White));
+
+    f.render_widget(desc_para, chunks[1]);
+}

--- a/src/visualizations/bar_spectrum.rs
+++ b/src/visualizations/bar_spectrum.rs
@@ -1,0 +1,121 @@
+use super::Visualization;
+use crate::audio::AudioState;
+use ratatui::style::Color;
+use ratatui::widgets::canvas::{Context, Rectangle};
+
+pub struct BarSpectrumVisualization;
+
+impl BarSpectrumVisualization {
+    pub fn new() -> Self {
+        BarSpectrumVisualization
+    }
+}
+
+impl Visualization for BarSpectrumVisualization {
+    fn name(&self) -> &str {
+        "Bar Spectrum"
+    }
+
+    fn description(&self) -> &str {
+        "Audio spectrum visualization with vertical bars"
+    }
+
+    fn render(&self, ctx: &mut Context, state: &AudioState) {
+        // Background - dark background
+        ctx.draw(&Rectangle {
+            x: 0.0,
+            y: 0.0,
+            width: 100.0,
+            height: 100.0,
+            color: Color::Rgb(10, 10, 20),
+        });
+
+        if state.is_playing {
+            let num_bars = 30;
+            let bar_width = 100.0 / num_bars as f64;
+            let spacing = 1.0;
+            let effective_width = bar_width - spacing;
+
+            // Generate pseudo-random bar heights based on bass impact and frame count
+            for i in 0..num_bars {
+                // Create a pseudo-random height using various parameters
+                let x_pos = (i as f64 / num_bars as f64) * 2.0 - 1.0; // Position from -1 to 1
+
+                // Use a combination of sine waves with different phases
+                // Based on frame count, position, and bass impact
+                let t = state.frame_count as f64 * 0.02;
+
+                // Height will be influenced by position, time, and bass impact
+                let phase1 = t * 0.5 + x_pos * 3.0;
+                let phase2 = t * 0.7 - x_pos * 2.0;
+                let phase3 = t * 0.3 + x_pos * 4.0;
+
+                // Combine multiple sine waves with different frequencies
+                let base_height =
+                    ((phase1.sin() * 0.5 + phase2.sin() * 0.3 + phase3.sin() * 0.2) + 1.0) / 2.0;
+
+                // Apply bass impact to make it more dynamic
+                let height = base_height * (0.3 + state.bass_impact * 0.7) * 70.0;
+
+                // Determine color based on height and bass impact
+                let intensity = (height / 70.0).min(1.0);
+                let color = Color::Rgb(
+                    ((0.2 + 0.8 * intensity) * 255.0) as u8,
+                    ((0.5 - 0.3 * intensity + state.bass_impact * 0.3) * 255.0) as u8,
+                    ((0.8 - 0.3 * intensity) * 255.0) as u8,
+                );
+
+                // Draw the bar
+                ctx.draw(&Rectangle {
+                    x: i as f64 * bar_width + spacing / 2.0,
+                    y: 100.0 - height,
+                    width: effective_width,
+                    height,
+                    color,
+                });
+            }
+
+            // Draw bass impact indicator at the bottom
+            let indicator_width = 50.0;
+            let indicator_height = 3.0;
+            let x = 50.0 - indicator_width / 2.0;
+            let y = 95.0;
+
+            // Background
+            ctx.draw(&Rectangle {
+                x,
+                y,
+                width: indicator_width,
+                height: indicator_height,
+                color: Color::Rgb(30, 30, 50),
+            });
+
+            // Filled portion based on bass impact
+            ctx.draw(&Rectangle {
+                x,
+                y,
+                width: indicator_width * state.bass_impact,
+                height: indicator_height,
+                color: Color::Rgb(
+                    100 + (155.0 * state.bass_impact) as u8,
+                    50 + (100.0 * (1.0 - state.bass_impact)) as u8,
+                    200,
+                ),
+            });
+        } else {
+            // Draw a static pattern when not playing
+            for i in 0..15 {
+                let height = 5.0 + (i as f64 % 5.0) * 3.0;
+                let x = 10.0 + i as f64 * 6.0;
+
+                ctx.draw(&Rectangle {
+                    x,
+                    y: 50.0 - height / 2.0,
+                    width: 3.0,
+                    height,
+                    color: Color::Rgb(50, 50, 100),
+                });
+            }
+        }
+    }
+}

--- a/src/visualizations/mod.rs
+++ b/src/visualizations/mod.rs
@@ -1,0 +1,118 @@
+use ratatui::widgets::canvas::Context;
+use std::fmt;
+
+use crate::audio::AudioState;
+
+// Trait for visualizations to implement
+pub trait Visualization {
+    fn render(&self, ctx: &mut Context, state: &AudioState);
+    fn name(&self) -> &str;
+    fn description(&self) -> &str;
+}
+
+// Visualization type enum for selecting visualization
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum VisualizationType {
+    Starfield,
+    BarSpectrum,
+    WaveForms,
+}
+
+impl fmt::Display for VisualizationType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            VisualizationType::Starfield => write!(f, "Starfield"),
+            VisualizationType::BarSpectrum => write!(f, "Bar Spectrum"),
+            VisualizationType::WaveForms => write!(f, "Wave Forms"),
+        }
+    }
+}
+
+// Module imports
+mod bar_spectrum;
+mod starfield;
+mod waveforms;
+
+// Re-exports
+pub use bar_spectrum::BarSpectrumVisualization;
+pub use starfield::StarfieldVisualization;
+pub use waveforms::WaveFormsVisualization;
+
+// Manager for handling visualizations
+pub struct VisualizationManager {
+    current_type: VisualizationType,
+    starfield: StarfieldVisualization,
+    bar_spectrum: BarSpectrumVisualization,
+    waveforms: WaveFormsVisualization,
+}
+
+impl VisualizationManager {
+    pub fn new() -> Self {
+        VisualizationManager {
+            current_type: VisualizationType::Starfield, // Default visualization
+            starfield: StarfieldVisualization::new(),
+            bar_spectrum: BarSpectrumVisualization::new(),
+            waveforms: WaveFormsVisualization::new(),
+        }
+    }
+
+    pub fn current_visualization(&self) -> &dyn Visualization {
+        match self.current_type {
+            VisualizationType::Starfield => &self.starfield,
+            VisualizationType::BarSpectrum => &self.bar_spectrum,
+            VisualizationType::WaveForms => &self.waveforms,
+        }
+    }
+
+    pub fn set_visualization_type(&mut self, vis_type: VisualizationType) {
+        self.current_type = vis_type;
+    }
+
+    pub fn current_type(&self) -> VisualizationType {
+        self.current_type
+    }
+
+    pub fn get_available_visualizations(&self) -> Vec<(VisualizationType, &str, &str)> {
+        vec![
+            (
+                VisualizationType::Starfield,
+                self.starfield.name(),
+                self.starfield.description(),
+            ),
+            (
+                VisualizationType::BarSpectrum,
+                self.bar_spectrum.name(),
+                self.bar_spectrum.description(),
+            ),
+            (
+                VisualizationType::WaveForms,
+                self.waveforms.name(),
+                self.waveforms.description(),
+            ),
+        ]
+    }
+
+    // These methods are commented out as they're not currently used,
+    // but might be useful for keyboard shortcuts in the future
+    /*
+    pub fn next_visualization(&mut self) {
+        self.current_type = match self.current_type {
+            VisualizationType::Starfield => VisualizationType::BarSpectrum,
+            VisualizationType::BarSpectrum => VisualizationType::WaveForms,
+            VisualizationType::WaveForms => VisualizationType::Starfield,
+        };
+    }
+
+    pub fn previous_visualization(&mut self) {
+        self.current_type = match self.current_type {
+            VisualizationType::Starfield => VisualizationType::WaveForms,
+            VisualizationType::BarSpectrum => VisualizationType::Starfield,
+            VisualizationType::WaveForms => VisualizationType::BarSpectrum,
+        };
+    }
+    */
+
+    pub fn render(&self, ctx: &mut Context, state: &AudioState) {
+        self.current_visualization().render(ctx, state);
+    }
+}

--- a/src/visualizations/starfield.rs
+++ b/src/visualizations/starfield.rs
@@ -1,0 +1,164 @@
+use super::Visualization;
+use crate::audio::AudioState;
+use ratatui::style::Color;
+use ratatui::widgets::canvas::{Context, Line, Rectangle};
+
+pub struct StarfieldVisualization;
+
+impl StarfieldVisualization {
+    pub fn new() -> Self {
+        StarfieldVisualization
+    }
+}
+
+impl Visualization for StarfieldVisualization {
+    fn name(&self) -> &str {
+        "Starfield"
+    }
+
+    fn description(&self) -> &str {
+        "3D starfield with warp effect"
+    }
+
+    fn render(&self, ctx: &mut Context, state: &AudioState) {
+        // Background - dark space
+        ctx.draw(&Rectangle {
+            x: 0.0,
+            y: 0.0,
+            width: 100.0,
+            height: 100.0,
+            color: Color::Rgb(0, 0, 20), // Very dark blue
+        });
+
+        // Star color palette
+        let colors = [
+            Color::Rgb(255, 255, 255), // White
+            Color::Rgb(200, 200, 255), // Light blue
+            Color::Rgb(255, 230, 200), // Light yellow
+            Color::Rgb(255, 200, 200), // Light red
+            Color::Rgb(200, 255, 200), // Light green
+        ];
+
+        // Draw each star in the starfield
+        for star in &state.stars {
+            // Calculate projected position based on perspective
+            // As z gets closer to 1.0, the star gets closer to the center
+            // and appears larger
+
+            // Center of screen
+            let center_x = 50.0;
+            let center_y = 50.0;
+
+            // Calculate projected position (perspective projection)
+            // Higher z = closer to viewer = further from center
+            let scale = 1.0 / (1.01 - star.z.min(0.99)); // Avoid division by zero
+            let projected_x = center_x + star.x * scale * 40.0; // Scale factor for width
+            let projected_y = center_y + star.y * scale * 40.0; // Scale factor for height
+
+            // Calculate size based on z (closer = larger)
+            // Use non-linear scaling for more dramatic effect
+            let size = star.z.powf(2.0) * 3.0 * (state.warp_speed * 0.5 + 0.5);
+
+            // Calculate brightness based on z and intrinsic brightness
+            let brightness = star.brightness * star.z.powf(1.5);
+
+            // Skip if star is out of bounds
+            if !(0.0..=100.0).contains(&projected_x) || !(0.0..=100.0).contains(&projected_y) {
+                continue;
+            }
+
+            // Get color for this star
+            let base_color = colors[star.color as usize % colors.len()];
+
+            // Adjust color based on brightness
+            let color = match base_color {
+                Color::Rgb(r, g, b) => Color::Rgb(
+                    (r as f64 * brightness) as u8,
+                    (g as f64 * brightness) as u8,
+                    (b as f64 * brightness) as u8,
+                ),
+                _ => base_color,
+            };
+
+            // Draw the star
+            ctx.draw(&Rectangle {
+                x: projected_x - size / 2.0,
+                y: projected_y - size / 2.0,
+                width: size,
+                height: size,
+                color,
+            });
+
+            // For closer stars, add a trail/streak effect when at high warp speed
+            if star.z > 0.7 && state.warp_speed > 1.5 {
+                // Calculate trail length based on speed and z
+                let trail_length = star.z * state.warp_speed * 5.0;
+
+                // Direction from center
+                let dx = projected_x - center_x;
+                let dy = projected_y - center_y;
+                let dist = (dx * dx + dy * dy).sqrt();
+
+                if dist > 0.0 {
+                    // Normalized direction
+                    let nx = dx / dist;
+                    let ny = dy / dist;
+
+                    // Draw trail pointing outward from center
+                    let trail_x = projected_x - nx * trail_length;
+                    let trail_y = projected_y - ny * trail_length;
+
+                    // Make trail fade out
+                    let trail_color = match color {
+                        Color::Rgb(r, g, b) => Color::Rgb(
+                            (r as f64 * 0.5) as u8,
+                            (g as f64 * 0.5) as u8,
+                            (b as f64 * 0.5) as u8,
+                        ),
+                        _ => color,
+                    };
+
+                    ctx.draw(&Line {
+                        x1: trail_x,
+                        y1: trail_y,
+                        x2: projected_x,
+                        y2: projected_y,
+                        color: trail_color,
+                    });
+                }
+            }
+        }
+
+        // Draw warp speed indicator
+        let warp = state.warp_speed;
+        if state.is_playing {
+            let indicator_width = 20.0;
+            let indicator_height = 5.0;
+            let x = 50.0 - indicator_width / 2.0;
+            let y = 90.0;
+
+            // Draw background
+            ctx.draw(&Rectangle {
+                x,
+                y,
+                width: indicator_width,
+                height: indicator_height,
+                color: Color::Rgb(30, 30, 50),
+            });
+
+            // Draw filled portion based on warp speed (1.0 to 3.0 mapped to 0-100%)
+            let fill_width = (warp - 1.0) / 2.0 * indicator_width;
+            ctx.draw(&Rectangle {
+                x,
+                y,
+                width: fill_width.min(indicator_width),
+                height: indicator_height,
+                color: Color::Rgb(
+                    (100.0 + (155.0 * (warp - 1.0) / 2.0)) as u8,
+                    (200.0 - (150.0 * (warp - 1.0) / 2.0)) as u8,
+                    255,
+                ),
+            });
+        }
+    }
+}

--- a/src/visualizations/waveforms.rs
+++ b/src/visualizations/waveforms.rs
@@ -1,0 +1,192 @@
+use super::Visualization;
+use crate::audio::AudioState;
+use ratatui::style::Color;
+use ratatui::widgets::canvas::{Context, Line};
+use std::f64::consts::PI;
+
+pub struct WaveFormsVisualization;
+
+impl WaveFormsVisualization {
+    pub fn new() -> Self {
+        WaveFormsVisualization
+    }
+}
+
+impl Visualization for WaveFormsVisualization {
+    fn name(&self) -> &str {
+        "Wave Forms"
+    }
+
+    fn description(&self) -> &str {
+        "Oscilloscope-style wave form visualization"
+    }
+
+    fn render(&self, ctx: &mut Context, state: &AudioState) {
+        // Background - gradient from dark blue to black
+        for y in 0..100 {
+            let color_intensity = (100 - y) as f64 * 0.2;
+            let color = Color::Rgb(0, 0, (color_intensity as u8).max(5));
+
+            ctx.draw(&Line {
+                x1: 0.0,
+                y1: y as f64,
+                x2: 100.0,
+                y2: y as f64,
+                color,
+            });
+        }
+
+        if state.is_playing {
+            // Draw horizontal grid lines
+            for y in (10..=90).step_by(20) {
+                let y = y as f64;
+                ctx.draw(&Line {
+                    x1: 0.0,
+                    y1: y,
+                    x2: 100.0,
+                    y2: y,
+                    color: Color::Rgb(30, 30, 50),
+                });
+            }
+
+            // Draw vertical grid lines
+            for x in (10..=90).step_by(10) {
+                let x = x as f64;
+                ctx.draw(&Line {
+                    x1: x,
+                    y1: 0.0,
+                    x2: x,
+                    y2: 100.0,
+                    color: Color::Rgb(30, 30, 50),
+                });
+            }
+
+            // Generate sine wave visualization based on frame count and bass impact
+            let t = state.frame_count as f64 * 0.02;
+            let num_points = 100;
+            let mut prev_x = 0.0;
+            let mut prev_y = 50.0;
+
+            for i in 1..=num_points {
+                let x = i as f64 / num_points as f64 * 100.0;
+
+                // Generate a more complex waveform using multiple frequencies
+                let freq1 = 1.0 + state.bass_impact * 2.0; // Base frequency affected by bass
+                let freq2 = 2.0 + state.bass_impact; // Second harmonic
+                let freq3 = 4.0; // Higher harmonic
+
+                // Combine different frequencies with varying amplitudes
+                let amp1 = 15.0 + state.bass_impact * 10.0; // Main amplitude
+                let amp2 = 5.0 * state.bass_impact; // Second amplitude affected strongly by bass
+                let amp3 = 3.0; // Small high-frequency component
+
+                // Calculate the waveform value
+                let phase = x / 100.0 * 2.0 * PI + t;
+                let wave = amp1 * (phase * freq1).sin()
+                    + amp2 * (phase * freq2).sin()
+                    + amp3 * (phase * freq3).sin() * state.bass_impact;
+
+                // Center the wave in the display and apply scaling
+                let y = 50.0 - wave;
+
+                // Only draw lines inside the canvas boundaries
+                if (0.0..=100.0).contains(&y) && (0.0..=100.0).contains(&prev_y) {
+                    // Determine color based on bass impact and position
+                    let intensity = 0.5 + state.bass_impact * 0.5;
+                    let color = Color::Rgb(
+                        ((0.2 + intensity * 0.8) * 255.0) as u8,
+                        ((0.8 - intensity * 0.3) * 255.0) as u8,
+                        ((0.7 + intensity * 0.3) * 255.0) as u8,
+                    );
+
+                    // Draw line segment
+                    ctx.draw(&Line {
+                        x1: prev_x,
+                        y1: prev_y,
+                        x2: x,
+                        y2: y,
+                        color,
+                    });
+                }
+
+                prev_x = x;
+                prev_y = y;
+            }
+
+            // Draw second wave (phase shifted) for more interesting effect
+            prev_x = 0.0;
+            prev_y = 50.0;
+
+            for i in 1..=num_points {
+                let x = i as f64 / num_points as f64 * 100.0;
+
+                // Similar to first wave but with phase shift and different parameters
+                let freq1 = 0.8 + state.bass_impact;
+                let freq2 = 3.0 - state.bass_impact;
+                let freq3 = 5.0;
+
+                let amp1 = 10.0;
+                let amp2 = 7.0 * state.bass_impact;
+                let amp3 = 2.0;
+
+                let phase = x / 100.0 * 2.0 * PI + t + PI / 2.0; // Phase shifted
+                let wave = amp1 * (phase * freq1).cos()
+                    + amp2 * (phase * freq2).sin()
+                    + amp3 * (phase * freq3).cos() * state.bass_impact;
+
+                let y = 50.0 - wave;
+
+                if (0.0..=100.0).contains(&y) && (0.0..=100.0).contains(&prev_y) {
+                    // Different color for second wave
+                    let color = Color::Rgb(
+                        ((0.7 - state.bass_impact * 0.2) * 255.0) as u8,
+                        ((0.2 + state.bass_impact * 0.6) * 255.0) as u8,
+                        ((0.8) * 255.0) as u8,
+                    );
+
+                    ctx.draw(&Line {
+                        x1: prev_x,
+                        y1: prev_y,
+                        x2: x,
+                        y2: y,
+                        color,
+                    });
+                }
+
+                prev_x = x;
+                prev_y = y;
+            }
+        } else {
+            // Draw a static pattern when not playing
+            // Central horizontal line
+            ctx.draw(&Line {
+                x1: 0.0,
+                y1: 50.0,
+                x2: 100.0,
+                y2: 50.0,
+                color: Color::Rgb(50, 50, 80),
+            });
+
+            // Small pulses
+            for i in 0..5 {
+                let x = 10.0 + i as f64 * 20.0;
+
+                ctx.draw(&Line {
+                    x1: x - 5.0,
+                    y1: 50.0,
+                    x2: x,
+                    y2: 45.0,
+                    color: Color::Rgb(60, 60, 100),
+                });
+
+                ctx.draw(&Line {
+                    x1: x,
+                    y1: 45.0,
+                    x2: x + 5.0,
+                    y2: 50.0,
+                    color: Color::Rgb(60, 60, 100),
+                });
+            }
+        }
+    }
+}


### PR DESCRIPTION
⏺ Add Modular Visualization System

  Description

  This PR implements a modular visualization system for Radio CLI that allows users to choose between different
  visualizations while listening to radio stations.

  The main features include:
  - A centralized visualization architecture with a common trait interface
  - Three different visualization types (Starfield, Bar Spectrum, and Wave Forms)
  - A visualization menu accessible via the 'v' key
  - Easy expansion for future visualization types

  Type of change

  - New feature (non-breaking change which adds functionality)

  How Has This Been Tested?

  - Manual testing of visualization switching
  - Verified visualization menu UI and navigation
  - Tested with and without active audio streams
  - Ensured existing functionality continues to work as expected

  Checklist:

  - My code follows the style guidelines of this project
  - I have performed a self-review of my own code
  - I have commented my code, particularly in hard-to-understand areas
  - My changes generate no new warnings
  - All code passes clippy checks